### PR TITLE
Enable httpd ExtendedStatus 

### DIFF
--- a/site/site_profile/files/etc/httpd/conf.d/server-status.conf
+++ b/site/site_profile/files/etc/httpd/conf.d/server-status.conf
@@ -1,5 +1,7 @@
 LoadModule status_module modules/mod_status.so
 
+ExtendedStatus On
+
 # Allow access to /server-status from localhost.
 # This is used by Munin.
 <Location /server-status>


### PR DESCRIPTION
so we can get apache accesses and volume info in Munin
