### PR TITLE
Reduce log level in PHP logs

### DIFF
--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -176,6 +176,7 @@ site_profile::web::php_opcache_ini:
   opcache.memory_consumption: 64
 
 # PHP-FPM configuration.
+php::fpm::daemon::log_level: 'warning'
 site_profile::web::php_fpm_conf:
   www:
     listen: '127.0.0.1:9000'


### PR DESCRIPTION
Ticket: #34 

* [x] Ready for review 
* [x] Ready for merge

Decrease PHP-FPM log level to Warning from Notice to avoid lots of noise in the logs when processes cycle.