### PR TITLE
Vagrant subdomain hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,10 @@ Vagrant.configure('2') do |config|
     end
   end
 
+  # Configure additional aliases for the hostsupdater plugin.
+  if defined? $host_aliases
+    config.hostsupdater.aliases = $host_aliases
+  end
 
   # Install r10k using the shell provisioner and download the Puppet modules
   config.vm.provision "shell", path: 'bootstrap.sh'

--- a/Vagrantfile.local.example
+++ b/Vagrantfile.local.example
@@ -20,7 +20,7 @@ $vms = {
 # Configure additional hostnames to be added to the host machine's /etc/hosts
 # file. Allows access to the VM on e.g. subdomains for multi-user testing.
 # Requires the vagrant-hostsupdater plugin.
-config.hostsupdater.aliases = ["dev.vagrant-multi1.cashmusic.org"]
+$host_aliases = ["dev.vagrant-multi1.cashmusic.org"]
 
 # Provide list of source mounts. The type defaults to virtualbox, but you could
 # also use nfs (on Mac/Linux) or the rsync type.

--- a/Vagrantfile.local.example
+++ b/Vagrantfile.local.example
@@ -17,6 +17,10 @@ $vms = {
   "default" => { "fqdn" => "vagrant-multi1.cashmusic.org", "ipaddress" => "10.10.10.20", "memory" => "1024", "cpus" => "2" },
   }
 
+# Configure additional hostnames to be added to the host machine's /etc/hosts
+# file. Allows access to the VM on e.g. subdomains for multi-user testing.
+# Requires the vagrant-hostsupdater plugin.
+config.hostsupdater.aliases = ["dev.vagrant-multi1.cashmusic.org"]
 
 # Provide list of source mounts. The type defaults to virtualbox, but you could
 # also use nfs (on Mac/Linux) or the rsync type.


### PR DESCRIPTION
Ticket: #35 

* [x] Ready for review 
* [x] Ready for merge

Adds `$host_aliases` variable to `Vagrantfile.local.example` to allow configuration of additional host aliases that will be auto-added to the host machine's `/etc/hosts` file if vagrant hostsupdater plugin is installed.