### PR TITLE
Remove abandoned repoforge repo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,17 +46,6 @@ Vagrant.configure('2') do |config|
     end
   end
 
-
-  # Optional share for yum packages so that they don't have be downloaded all the time
-  # when doing a clean build of different VMs.
-  # To turn this on, set vagrant_yum_cache in your Vagrantfile.local,
-  # $vagrant_yum_cache = "/var/cache/vagrantyum_cache"
-  if defined? $vagrant_yum_cache
-    config.vm.synced_folder $vagrant_yum_cache, "/var/cache/yum"
-    config.vm.provision "shell",
-      inline: "echo '--- Turning on yum caching in /etc/yum.conf ---'; perl -pi.bak -e 's/keepcache=0/keepcache=1/' /etc/yum.conf"
-  end
-
   # Mount any development directories
   if defined? $dev_mounts
     # Default mount settings.

--- a/hiera/common.yaml
+++ b/hiera/common.yaml
@@ -89,8 +89,8 @@ system_groups:
 # Default to Rackspace EPEL mirror.
 yumrepos::epel::epel_url: http://mirror.rackspace.com/epel/6/x86_64/
 
-# Use repoforge repo sparingly.
-yumrepos::repoforge::repoforge_includepkgs: mod_fastcgi
+# Exclude http* packages from IUS.
+yumrepos::ius::ius_exclude: 'http*'
 
 
 #############################################

--- a/site/site_profile/manifests/web.pp
+++ b/site/site_profile/manifests/web.pp
@@ -75,11 +75,23 @@ class site_profile::web {
   }
 
   # Setup fastcgi configuration to point to php-fpm.
-  class { 'yumrepos::repoforge': }
+  # Remove old/broken repoforge repo.
+  yumrepo { 'repoforge':
+    ensure => absent,
+  }
+
+  # Add Tag1 repo for mod_fastcgi.
+  yumrepo { 'tag1-fastcgi':
+    descr    => 'tag1-fastcgi',
+    baseurl  => 'https://pkg.tag1consulting.com/mod_fastcgi/el6/x86_64/',
+    enabled  => '1',
+    gpgcheck => '1',
+    gpgkey   => 'https://pkg.tag1consulting.com/RPM-GPG-KEY-TAG1',
+  }
 
   package { "mod_fastcgi":
     ensure => present,
-    require => Class['yumrepos::repoforge'],
+    require => Yumrepo['tag1-fastcgi'],
   }
 
   # TODO: this should be in a template, configurable with hiera values.


### PR DESCRIPTION
Replaces it with a custom repo containing only mod_fastcgi.
Also disables `http*` packages from being installed via IUS repo, and removes unused yum cache mount.